### PR TITLE
Update composition.md

### DIFF
--- a/help/xdm/schema/composition.md
+++ b/help/xdm/schema/composition.md
@@ -166,7 +166,7 @@ A field is the most basic building block of a schema. Fields provide constraints
 
 * String
 * Integer
-* Number
+* Double
 * Boolean
 * Array
 * Object


### PR DESCRIPTION
There isn't a data type called Number anymore, as far as I can tell. If I'm wrong, feel free to disregard. But for example when capturing Revenue (a non-integer), it seems that people are choosing Double as the data type. Number isn't anywhere on the list when building a field in a mixin.