### PR TITLE
Wrong syntax on library information example code

### DIFF
--- a/help/edge/fundamentals/debugging.md
+++ b/help/edge/fundamentals/debugging.md
@@ -67,8 +67,8 @@ When debugging is set through the `debug` command or query string parameter, it 
 It's often helpful to access some of the details behind the library you have loaded onto your website. To do this, execute the `getLibraryInfo` command as follows:
 
 ```js
-alloy("getLibraryInfo").then(function(libraryInfo) {
-  console.log(libraryInfo.version);
+alloy("getLibraryInfo").then(function(data) {
+  console.log(data.libraryInfo.version);
 });
 ```
 


### PR DESCRIPTION
The example on retrieving library information returns undefined as the version is nested one further level down than the example provided IE: libraryInfo.libraryInfo.version. Rather than the duplication of 'libraryInfo' I changed the function argument to data so it becomes data.libraryInfo.version however will defer to Adobes knowledge.