### PR TITLE
Normalize "Tags" casing

### DIFF
--- a/help/edge/consent/iab-tcf/with-launch.md
+++ b/help/edge/consent/iab-tcf/with-launch.md
@@ -1,17 +1,17 @@
 ---
-title: Integrate IAB TCF 2.0 Support using tags and the Platform Web SDK Extension
-description: Learn how to set up IAB TCF 2.0 consent with tags and the Adobe Experience Platform Web SDK extension.
+title: Integrate IAB TCF 2.0 Support using Tags and the Platform Web SDK Extension
+description: Learn how to set up IAB TCF 2.0 consent with Tags and the Adobe Experience Platform Web SDK extension.
 exl-id: dc0e6b68-8257-4862-9fc4-50b370ef204f
 ---
-# Integrate IAB TCF 2.0 support using tags and the Platform Web SDK extension
+# Integrate IAB TCF 2.0 support using Tags and the Platform Web SDK extension
 
-Adobe Experience Platform Web SDK supports the Interactive Advertising Bureau Transparency & Consent Framework, version 2.0 (IAB TCF 2.0). This guide shows you how to set up a tag property for sending IAB TCF 2.0 consent information to Adobe using the Adobe Experience Platform Web SDK tag extension.
+Adobe Experience Platform Web SDK supports the Interactive Advertising Bureau Transparency & Consent Framework, version 2.0 (IAB TCF 2.0). This guide shows you how to set up a Tag property for sending IAB TCF 2.0 consent information to Adobe using the Adobe Experience Platform Web SDK Tags extension.
 
-If you do not wish to use tags, please refer to the guide on [using IAB TCF 2.0 without tags](./without-launch.md).
+If you do not wish to use Tags, please refer to the guide on [using IAB TCF 2.0 without Tags](./without-launch.md).
 
 ## Getting started
 
-In order to use IAB TCF 2.0 with tags and the Platform Web SDK extension, you need to have an XDM schema and dataset available.
+In order to use IAB TCF 2.0 with Tags and the Platform Web SDK extension, you need to have an XDM schema and dataset available.
 
 Additionally, this guide requires you to have a working understanding of Adobe Experience Platform Web SDK. For a quick refresher, please read the [Adobe Experience Platform Web SDK overview](../../home.md) and the [Frequently asked questions](../../web-sdk-faq.md) documentation.
 
@@ -23,7 +23,7 @@ For more information on how to configure default consent, refer to the [default 
 
 ## Updating Profile with consent information {#consent-code-1}
 
-To call the `setConsent` action when your customers consent preferences have changed, you need to create a new tag rule. Start by adding a new event and choose the Core extension's "Custom Code" event type.
+To call the `setConsent` action when your customers consent preferences have changed, you need to create a new Tag rule. Start by adding a new event and choose the Core extension's "Custom Code" event type.
 
 Use the following code sample for your new event:
 


### PR DESCRIPTION
Should help users understand this is referencing Tags, by Adobe and not generic HTML tags.

Side note - For describing things that belong inside Tags, is the s removed? E.g. - is it a "Tag Property" or a "Tags Property"?