### PR TITLE
Fixed a permission name and added one that is missing

### DIFF
--- a/help/collection/permissions.md
+++ b/help/collection/permissions.md
@@ -52,7 +52,8 @@ Permissions under Adobe Experience Platform Data Collection control access to ta
 | Property Rights | Manage Extensions | Grants the ability to manage the [extensions](../tags/ui/managing-resources/extensions/overview.md) for the properties a user has access to. |
 | Property Rights | Publish | Grants the ability to publish a library build as part of the [publishing flow](../tags/ui/publishing/publishing-flow.md). |
 | Company Rights | Develop Extensions | Grants the ability to create and modify extension packages that are owned by your organization, including private releases and requests for public release. |
-| Company Rights | Manage Extensions | This permission is only applicable if you have a license for Adobe Journey Optimizer or another solution that grants access to mobile in-app and push messaging. This allows you to manage the apps that Adobe Experience Cloud knows about along with the necessary push credentials needed to communicate with the Firebase Cloud Messaging service and the Apple Push Notification service. |
+| Company Rights | Manage App Configurations | This permission is only applicable if you have a license for Adobe Journey Optimizer or another solution that grants access to mobile in-app and push messaging. This allows you to manage the apps that Adobe Experience Cloud knows about along with the necessary push credentials needed to communicate with the Firebase Cloud Messaging service and the Apple Push Notification service. |
+| Company Rights | Manage Properties | [This is missing and I don't have the right description]
 
 {style="table-layout:auto"}
 


### PR DESCRIPTION
One of the rows should be called "Manage App Configurations" instead of "Manage Extensions", and the "Manage properties" permission is missing from the docs - but I don't have the description for it, I was actually hoping to find it when I found these issues.