### PR TITLE
Update accessing-the-ecid.md

### DIFF
--- a/help/tags/extensions/client/web-sdk/accessing-the-ecid.md
+++ b/help/tags/extensions/client/web-sdk/accessing-the-ecid.md
@@ -27,9 +27,9 @@ Then, set the target to an XDM path where the field is of type `string`.
 If you need to access the [!DNL ECID] on the client side, use the tags approach as described below.
 
 1. Ensure your property is configured with [rule component sequencing](../../../ui/managing-resources/rules.md#sequencing) enabled. 
-1. Create a new rule.
+1. Create a new rule. This rule should be used exclusively for capturing the [!DNL ECID] without any other important actions.
 1. Add a [!UICONTROL Library Loaded] event to the rule.
-1. Add a [!UICONTROL Custom Condition] action to the rule with the following code (assuming the name you've configured for the SDK instance is `alloy`):
+1. Add a [!UICONTROL Custom Code] action to the rule with the following code (assuming the name you've configured for the SDK instance is `alloy` and there isn't already a data element of the same name):
 
    ```js
     return alloy("getIdentity")


### PR DESCRIPTION
- Removed reference to "custom condition", should read "custom code"
+ mentioned the importance of using an isolated rule to run getIdentity command, since failure blocks other rule actions
+ mentioned using a distinct data element for capturing ECID since there could be issues where data element is overwritten otherwise