### PR TITLE
Update identitymap.md

### DIFF
--- a/help/xdm/field-groups/profile/identitymap.md
+++ b/help/xdm/field-groups/profile/identitymap.md
@@ -10,7 +10,7 @@ exl-id: c9928e85-ef1e-4739-ba1d-80505a9e60c3
 >
 >The names of several schema field groups have changed. See the document on [field group name updates](../name-updates.md) for more information.
 
-[!UICONTROL IdentityMap] is a standard schema field group for the [[!DNL XDM Individual Profile] class](../../classes/individual-profile.md). The field group provides a single map field, which contains a set of user identities keyed by namespace.
+[!UICONTROL IdentityMap] is a standard schema field group for the [[!UICONTROL XDM ExperienceEvent] class](../../classes/experienceevent.md). The field group provides a single map field, which contains a set of user identities keyed by namespace.
 
 ![A diagram of the [!UICONTROL IdentityMap] schema field group](../../images/field-groups/identitymap.png)
 


### PR DESCRIPTION
Currently, this incorrectly states the identityMap as a standard field group for the XDM Individual Profile class; however, I see that identityMap is in the XDM ExperienceEvent class today. 

I'm also unfamiliar with the codebase syntax to update the URL to the XDM ExperienceEvent class page, so please feel free to correct if needed. Here is the updated page URL: https://experienceleague.adobe.com/en/docs/experience-platform/xdm/classes/experienceevent 

Thanks!