### PR TITLE
Update faq.md

### DIFF
--- a/help/web-sdk/faq.md
+++ b/help/web-sdk/faq.md
@@ -75,7 +75,7 @@ Adobe Experience Platform Web SDK can also send data directly to Adobe Experienc
 
 ## Do customers need to buy Adobe Experience Platform to use the [!DNL Web SDK]?
 
-No. Any Adobe Digital Experience customer can use the Adobe Experience Platform Web SDK free of charge. Customers who wish to use the [!DNL Web SDK] will need to configure the right permissions to create schemas, datasets, identity namespaces, and datastreams in the Data Collection UI or Experience Platform UI.
+No. Any Adobe Digital Experience customer can use the Adobe Experience Platform Web SDK free of charge. Customers who wish to use the [!DNL Web SDK] will need to configure the right permissions to create schemas and datastreams in the Data Collection UI or Experience Platform UI.
 
 For more information on configuring these permissions see our documentation on [data collection permissions management](https://experienceleague.adobe.com/docs/experience-platform/collection/permissions.html).
 


### PR DESCRIPTION
Updated faq to fix "

Do customers need to buy Adobe Experience Platform to use the Web SDK? No. Any Adobe Digital Experience customer can use the Adobe Experience Platform Web SDK free of charge. Customers who wish to use the Web SDK will need to configure the right permissions to create schemas, datasets, identity namespaces, and datastreams in the Data Collection UI or Experience Platform UI."     

non-AEP/RTCDP clients can not created datasets or identiies.