### PR TITLE
Updated the spelling of Response for file upload section.

### DIFF
--- a/help/ingestion/batch-ingestion/overview.md
+++ b/help/ingestion/batch-ingestion/overview.md
@@ -176,7 +176,7 @@ curl -X PUT "https://platform.adobe.io/data/foundation/import/batches/{BATCH_ID}
 | -------- | ----------- |
 | `{FILE_PATH_AND_NAME}` | The path and filename of the file to be uploaded into the dataset. |
 
-**Reponse**
+**Response**
 
 ```JSON
 #Status 200 OK, with empty response body


### PR DESCRIPTION
Updated the spelling of Response for file upload section. under small file upload. Earlier the spelling was 'Reponse'