### PR TITLE
Update onetrust.md

### DIFF
--- a/help/sources/tutorials/api/create/consent-and-preferences/onetrust.md
+++ b/help/sources/tutorials/api/create/consent-and-preferences/onetrust.md
@@ -751,8 +751,13 @@ curl -X POST \
               "sourceType": "ATTRIBUTE",
               "source": "content.Purposes",
               "destination": "_exchangesandboxbravo.Purposes"
+          },
+          {
+              "sourceType": "ATTRIBUTE",
+              "source": "content.LinkToken",
+              "destination": "_exchangesandboxbravo.LinkToken",
+              "description": "Link Token"
           }
-
       ]
   }'
 ```


### PR DESCRIPTION
OneTrust <> AEP connector: Change log

This file contains documentation update requests.

## July 10th, 2025

LinkToken (MagicLink) is now supported, updated mapping step to highlight this change.

- Document URL that needs to be updated: https://experienceleague.adobe.com/en/docs/experience-platform/sources/api-tutorials/create/consent/onetrust
- Please update request payload under title "Create a mapping"