### PR TITLE
Update export frequency and maximum file size

### DIFF
--- a/help/destinations/catalog/advertising/liveramp-onboarding.md
+++ b/help/destinations/catalog/advertising/liveramp-onboarding.md
@@ -80,7 +80,7 @@ Refer to the table below for information about the destination export type and f
 | Item | Type | Notes |
 |---------|----------|---------|
 | Export type | **[!UICONTROL Audience export]** | You are exporting all members of an audience with the identifiers (name, phone number, or others) used in the [!DNL LiveRamp - Onboarding] destination.|
-| Export frequency | **[!UICONTROL Batch]** | As profiles are updated in Experience Platform based on audience evaluation, the profiles (identities) are updated and can be delivered downstream to the destination platform on a daily, weekly, or monthly cadence. Read more about [batch file-based destinations](/help/destinations/destination-types.md#file-based).|
+| Export frequency | **[!UICONTROL Batch]** | As profiles are updated in Experience Platform based on audience evaluation, the profiles (identities) are updated and can be delivered downstream to the destination platform on a one-time, daily, weekly, or monthly cadence. Read more about [batch file-based destinations](/help/destinations/destination-types.md#file-based).|
 
 {style="table-layout:auto"}
 
@@ -162,7 +162,7 @@ Read [Activate audience data to batch profile export destinations](/help/destina
 In the [!UICONTROL Scheduling] step, create an export schedule for each audience, with the settings shown below.
 
 * **[!UICONTROL File export options]**: [!UICONTROL Export full files]. [Incremental file exports](../../ui/activate-batch-profile-destinations.md#export-incremental-files) are currently not supported for the [!DNL LiveRamp] destination.
-* **[!UICONTROL Frequency]**: [!UICONTROL Daily], [!UICONTROL Weekly], or [!UICONTROL Monthly]
+* **[!UICONTROL Frequency]**: [!UICONTROL ONCE], [!UICONTROL Daily], [!UICONTROL Weekly], or [!UICONTROL Monthly]
 * **[!UICONTROL Date]**: Select the export start and end times as you wish.
 
 ![Experience Platform UI screenshot showing the audience scheduling step.](../../assets/catalog/advertising/liveramp-onboarding/liveramp_scheduling_screenshot.png)
@@ -215,7 +215,7 @@ Once you've added all your desired mappings, select **[!UICONTROL Next]** and fi
 
 Your data is exported to the [!DNL LiveRamp - Onboarding] storage location that you configured, as CSV files.
 
-Exported files have a maximum size of 10 million rows. Experience Platform generates multiple files per delivery if the selected audiences exceed 10 million rows. If you expect to exceed the single file limit, contact your [!DNL LiveRamp] representative and ask them to configure batch ingestion for you.
+Exported files have a maximum size of 100 million rows. Experience Platform generates multiple files per delivery if the selected audiences exceed 100 million rows. If you expect to exceed the single file limit, contact your [!DNL LiveRamp] representative and ask them to configure batch ingestion for you.
 
 When exporting files to the [!DNL LiveRamp - Onboarding] destination, Experience Platform generates one CSV file for each [merge policy ID](../../../profile/merge-policies/overview.md).
 
@@ -285,6 +285,7 @@ This section captures the functionality and significant documentation updates ma
 
 |Release month|Update type|Description|
 |---|---|---|
+|June 2026| Functionality and documentation update|<ul><li> Added support for one-time delivery cadence.</li><li> Increased maximum file size to 100 million rows (from 10 million, previously).|
 |February 2025| Functionality and documentation update|<ul><li> Added support for weekly and monthly delivery cadences.|
 |March 2024|Functionality and documentation update|<ul><li>Added support for deliveries to Europe and Australia [!DNL LiveRamp] [!DNL SFTP] instances.</li><li>Updated documentation to describe specific configurations for newly supported regions.</li><li>Increased maximum file size to 10 million rows (from 5 million, previously).</li><li>Updated documentation to reflect increased file sizes.</li></ul>|
 |July 2023|Initial release|Initial destination release and documentation published.|


### PR DESCRIPTION
Documentation updates to accompany publish request accounting for:
- adding one-time scheduling cadence
- increased file size of 100 million rows